### PR TITLE
Replace back-slashes in file separator with forward ones

### DIFF
--- a/src/sass-shake.js
+++ b/src/sass-shake.js
@@ -77,10 +77,13 @@ const isExcluded = (file, exclusions) =>
  * @param { Array } exclusions
  * @returns { Boolean } is the file unused
  */
-const isUnused = (file, filesInSassTree, exclusions) =>
-  isSassFile(file)
+const isUnused = (file, filesInSassTree, exclusions) => {
+  file = file.split('\\').join('/');
+	
+  return isSassFile(file)
   && !isExcluded(file, exclusions)
   && !filesInSassTree.includes(file);
+}
 
 /**
  * Compare directory contents with a list of files that are in use

--- a/src/sass-shake.js
+++ b/src/sass-shake.js
@@ -39,7 +39,7 @@ const findEntryPoints = (directory) =>
  */
 async function getDependencies(includePaths, file) {
   const result = await util.promisify(sass.render)({ includePaths, file });
-  return result.stats.includedFiles;
+  return result.stats.includedFiles.map(path.normalize);
 };
 
 /**
@@ -77,13 +77,9 @@ const isExcluded = (file, exclusions) =>
  * @param { Array } exclusions
  * @returns { Boolean } is the file unused
  */
-const isUnused = (file, filesInSassTree, exclusions) => {
-  file = file.split('\\').join('/');
-	
-  return isSassFile(file)
+const isUnused = (file, filesInSassTree, exclusions) => isSassFile(file)
   && !isExcluded(file, exclusions)
   && !filesInSassTree.includes(file);
-}
 
 /**
  * Compare directory contents with a list of files that are in use


### PR DESCRIPTION
This prevents it from skipping all files when comparing files in Windows