### PR TITLE
Fixes CLI delete option

### DIFF
--- a/bin/sass-shake.js
+++ b/bin/sass-shake.js
@@ -11,7 +11,7 @@ program
   .option('-f, --entryPoints <entryPoints>', 'Sass entry point files', list)
   .option('-e, --exclude <exclusions>', 'An array of regexp pattern strings that are matched against files to exclude them from the unused files list', list, [])
   .option('-s, --silent', 'Suppress logs')
-  .option('-d, --deleteFiles', 'Delete the unused files')
+  .option('-d, --delete', 'Delete the unused files')
   .option('-t, --hideTable', 'Hide the unused files table')
   .parse(process.argv);
 


### PR DESCRIPTION
The option parameter was being ignored as it was called delete instead of the CLI deleteFiles and it wouldn't work.